### PR TITLE
Expose I2C address as static member of the driver.

### DIFF
--- a/examples/get_display.toit
+++ b/examples/get_display.toit
@@ -16,8 +16,8 @@ get_display -> PixelDisplay:
     --frequency=800_000
 
   devices := bus.scan
-  if not devices.contains SSD1306_ID: throw "No SSD1306 display found"
+  if not devices.contains SSD1306.I2C_ADDRESS: throw "No SSD1306 display found"
 
-  driver := SSD1306.i2c (bus.device SSD1306_ID)
+  driver := SSD1306.i2c (bus.device SSD1306.I2C_ADDRESS)
 
   return TwoColorPixelDisplay driver

--- a/src/ssd1306.toit
+++ b/src/ssd1306.toit
@@ -108,6 +108,8 @@ Intended to be used with the Pixel-Display package
 See https://docs.toit.io/language/sdk/display
 */
 abstract class SSD1306 extends AbstractDriver:
+  static I2C_ADDRESS ::= 0x3c
+  static I2C_ADDRESS_ALT ::= 0x3d
 
   /**
   Deprecated. Use the $SSD1306.i2c constructor instead.
@@ -196,4 +198,5 @@ abstract class SSD1306 extends AbstractDriver:
       send_data_buffer_ line_buffer
 
 /// I2C ID of an SSD1306 display.
-SSD1306_ID ::= 0x3c
+/// Deprecated. Use $SSD1306.I2C_ADDRESS instead.
+SSD1306_ID ::= SSD1306.I2C_ADDRESS


### PR DESCRIPTION
This makes this driver more consistent with other drivers.